### PR TITLE
feat: add development docker containers

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -16,11 +16,16 @@ jobs:
       - name: Authenticate with Docker Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - name: Build Container
+      - name: Build Main Container
         run: docker build -t defrostedtuna/php-nginx:7.3 . -f php-7.3/Dockerfile
 
-      - name: Push Container
-        run: docker push defrostedtuna/php-nginx:7.3
+      - name: Build Dev Container
+        run: docker build -t defrostedtuna/php-nginx:7.3-dev . -f php-7.3/dev.Dockerfile
+
+      - name: Push Containers
+        run: |
+          docker push defrostedtuna/php-nginx:7.3
+          docker push defrostedtuna/php-nginx:7.3-dev
 
   build-php-74:
     name: PHP 7.4
@@ -32,11 +37,16 @@ jobs:
       - name: Authenticate with Docker Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - name: Build Container
+      - name: Build Main Container
         run: docker build -t defrostedtuna/php-nginx:7.4 . -f php-7.4/Dockerfile
 
-      - name: Push Container
-        run: docker push defrostedtuna/php-nginx:7.4
+      - name: Build Dev Container
+        run: docker build -t defrostedtuna/php-nginx:7.4-dev . -f php-7.4/dev.Dockerfile
+
+      - name: Push Containers
+        run: |
+          docker push defrostedtuna/php-nginx:7.4
+          docker push defrostedtuna/php-nginx:7.4-dev
 
   build-php-80:
     name: PHP 8.0
@@ -48,8 +58,13 @@ jobs:
       - name: Authenticate with Docker Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - name: Build Container
+      - name: Build Main Container
         run: docker build -t defrostedtuna/php-nginx:8.0 . -f php-8.0/Dockerfile
 
-      - name: Push Container
-        run: docker push defrostedtuna/php-nginx:8.0
+      - name: Build Dev Container
+        run: docker build -t defrostedtuna/php-nginx:8.0-dev . -f php-8.0/dev.Dockerfile
+
+      - name: Push Containers
+        run: |
+          docker push defrostedtuna/php-nginx:8.0
+          docker push defrostedtuna/php-nginx:8.0-dev

--- a/README.md
+++ b/README.md
@@ -3,16 +3,38 @@
 ## Description
 This is a Docker container that runs PHP and Nginx in a single instance. Primarily intended for use with Laravel applications, the image is built on top of Alpine Linux and ties the two main processes together using Supervisor. In the event either process dies, Supervisor will detect this failure and kill the entire container.
 
-To use with this container for a project, simply pull down the desired version.
+## Usage
+
+Images are versioned based on the PHP version used within the container. For example; 
+
+* `defrostedtuna/php-nginx:7.3` -> PHP `7.3`
+* `defrostedtuna/php-nginx:8.0` -> PHP `8.0`
+
+To use with this container for a project, simply pull down the desired version and configure it to your needs.
 
 ```bash
 # CLI
 docker pull defrostedtuna/php-nginx:8.0
+
+docker run -it -v $(pwd):/app defrostedtuna/php-nginx:8.0
 ```
 
 ```Dockerfile
 # Dockerfile
 FROM defrostedtuna/php-nginx:8.0
+
+# Copy the project files.
+COPY . /app
+
+# Install dependencies.
+RUN composer install --no-dev --optimize-autoloader
+
+# Set application permissions.
+RUN chown -R www:www /app
+RUN chmod -R ug+rwx /app/storage /app/bootstrap/cache
+RUN chmod -R 774 /app/storage/logs
+
+# Additional container configuration here...
 ```
 
 ```yaml
@@ -22,13 +44,13 @@ version: '3.5'
 services:
   app:
     image: defrostedtuna/php-nginx:8.0
+    container_name: app
+    working_dir: /app
+    volumes:
+      - ./:/app # The application lives within the '/app' directory in the Docker container.
+
     # Additional container configuration here...
 ```
-
-Images will be versioned based on the PHP version used within the container. For example; 
-
-* `defrostedtuna/php-nginx:7.3` -> PHP `7.3`
-* `defrostedtuna/php-nginx:8.0` -> PHP `8.0`
 
 ## Packages
 
@@ -60,80 +82,76 @@ Packages installed via Alpine's native manager include the following;
 * `unzip`
 * `zip`
 
-Composer has also been bundled in so that PHP dependencies may be installed from within the Docker container. Installing these dependencies from within the context of the container will ensure that versions are consistent across environments. Composer's version is controlled via each Dockerfile as to ensure compatibility in the event Composer receives an update. This covers odd scenarios where pulling the most recent version of Composer may conflict with the installed packages or dependencies.
+**Composer** has also been bundled in so that PHP dependencies may be installed from within the Docker container. Installing these dependencies from within the context of the container will ensure that versions are consistent across environments. Composer's version is controlled via each dockerfile as to ensure compatibility in the event Composer receives an update. This covers odd scenarios where pulling the most recent version of Composer may conflict with the installed packages or dependencies.
 
-Dev dependencies such as `php-xdebug` and `php-sqlite` should be included in a development Dockerfile that extends this base image to keep the production Docker container free of unused items. Splitting dependencies this way allows for the segregation of resources for development environments, while still maintaining a relatively clean image for production. 
+## Development Dockerfile
 
-## Building Images
+Dev dependencies such as `php-xdebug` and `php-sqlite` have been _excluded_ from the main container in order to keep the production Docker container lean and free of unused items. Splitting dependencies this way allows for the segregation of resources for development environments while still maintaining a relatively clean image for production.
 
-Images are built using GitHub Actions and are pushed to Docker Hub for public consumption. In the event it is desirable to build the images locally, the proper context and file must be specified. This is due to the nested structure of the repository.
+With this being the case, development containers exist alongside each main release and include a base set of dependencies useful for developing with Docker locally. Extra dependencies bundled with the development container include;
 
-A global set of configuration files are specified at the root of this project that should apply to each container that is built. The Dockerfiles for each container are stored in their own subdirectory so that specific configuration overrides may be stored alongside the corresponding container. Docker cannot reach out to the parent directory relative to the context that is set to retrieve these global configuration files, so the context and file must be specified independently.
+* `php-sqlite`
+* `php-pdo_sqlite`
+* `php-xdebug`
+
+The development Docker container is configured to automatically enable `xdebug` for use with code coverage drivers. 
+
+Development containers can be used by simply appending the `-dev` suffix to the end of the desired image version. For example; 
+
+* `defrostedtuna/php-nginx:7.3-dev`
+* `defrostedtuna/php-nginx:8.0-dev`
 
 ```bash
-# Set the context to the root of the project, while specifying the desired Dockerfile
+# CLI
+docker pull defrostedtuna/php-nginx:8.0-dev
 
-docker build -t defrostedtuna/php-nginx:8.0 . -f php-8.0/Dockerfile
+docker run -it -v $(pwd):/app defrostedtuna/php-nginx:8.0-dev
 ```
-
-## Example Project Setup
-
-An example application that utilizes this image could look like the following;
-
-```
-├── ...
-├── dev.Dockerfile
-├── docker-compose.yaml
-├── Dockerfile
-├── ...
-```
-
-The `dev.Dockerfile` would contain any additional dependencies required for testing or debugging.
 
 ```Dockerfile
-FROM defrostedtuna/php-nginx:8.0
-
-# Add sqlite and xdebug for development purposes.
-RUN apk add --no-cache \
-    php8-pdo_sqlite \
-    php8-sqlite3 \
-    php8-xdebug
-
-# Enable the xdebug extension.
-# `/etc/php` has been symlinked to `/etc/php{version}` on the parent container for ease of use.
-RUN echo zend_extension=xdebug.so >> /etc/php/conf.d/xdebug.ini
-```
-
-This `dev.Dockerfile` would be used to bootstrap the application via a `docker-compose.yaml` file when developing on a local machine.
-
-```yaml
-version: '3.5'
-
-services:
-  app:
-    build:
-      context: .
-      dockerfile: dev.Dockerfile
-    container_name: app
-    working_dir: /app
-    volumes:
-      - ./:/app # The application contents live within the `/app` directory in the Docker container.
-    # Additional container configuration here...
-```
-
-Likewise, the production `Dockerfile` would be free to create the application in a way that is optimal for a production environment.
-
-```Dockerfile
-FROM defrostedtuna/php-nginx:8.0
+# Dockerfile
+FROM defrostedtuna/php-nginx:8.0-dev
 
 # Copy the project files.
 COPY . /app
 
-# Install dependencies.
-RUN composer install --no-dev --optimize-autoloader
+# Install dependencies (optional for development).
+RUN composer install
 
 # Set application permissions.
 RUN chown -R www:www /app
 RUN chmod -R ug+rwx /app/storage /app/bootstrap/cache
 RUN chmod -R 774 /app/storage/logs
+
+# Additional container configuration here...
+```
+
+```yaml
+# docker-compose
+version: '3.5'
+
+services:
+  app:
+    image: defrostedtuna/php-nginx:8.0-dev
+    container_name: app
+    working_dir: /app
+    volumes:
+      - ./:/app # The application lives within the '/app' directory in the Docker container.
+
+    # Additional container configuration here...
+```
+
+## Building Images
+
+Images are built using GitHub Actions and are pushed to Docker Hub for public consumption. In the event it is desirable to build the images locally, the proper context and file must be specified. This is due to the nested structure of the repository.
+
+A global set of configuration files are specified at the root of the repository that should apply to each container that is built. The dockerfiles for each container are stored in their own subdirectory so that specific configuration overrides may be stored alongside the corresponding container. Docker cannot reach out to the parent directory relative to the context that is set to retrieve these global configuration files, so the context and file must be specified explicitly.
+
+```bash
+# Set the context to the root of the project, while specifying the desired Dockerfile
+
+docker build -t defrostedtuna/php-nginx:8.0 . -f php-8.0/Dockerfile
+
+# Development Dockerfile
+docker build -t defrostedtuna/php-nginx:8.0-dev . -f php-8.0/dev.Dockerfile
 ```

--- a/php-7.3/dev.Dockerfile
+++ b/php-7.3/dev.Dockerfile
@@ -1,0 +1,12 @@
+FROM defrostedtuna/php-nginx:7.3
+
+# Add sqlite and xdebug for development purposes.
+RUN apk add --no-cache \
+  php7-pdo_sqlite \
+  php7-sqlite3 \
+  php7-xdebug
+
+# Enable the xdebug extension.
+# `/etc/php` has been symlinked to `/etc/php{version}` on the parent container for ease of use.
+RUN echo zend_extension=xdebug.so >> /etc/php/conf.d/xdebug.ini
+ENV XDEBUG_MODE=coverage

--- a/php-7.4/dev.Dockerfile
+++ b/php-7.4/dev.Dockerfile
@@ -1,0 +1,12 @@
+FROM defrostedtuna/php-nginx:7.4
+
+# Add sqlite and xdebug for development purposes.
+RUN apk add --no-cache \
+  php7-pdo_sqlite \
+  php7-sqlite3 \
+  php7-xdebug
+
+# Enable the xdebug extension.
+# `/etc/php` has been symlinked to `/etc/php{version}` on the parent container for ease of use.
+RUN echo zend_extension=xdebug.so >> /etc/php/conf.d/xdebug.ini
+ENV XDEBUG_MODE=coverage

--- a/php-8.0/dev.Dockerfile
+++ b/php-8.0/dev.Dockerfile
@@ -1,0 +1,12 @@
+FROM defrostedtuna/php-nginx:8.0
+
+# Add sqlite and xdebug for development purposes.
+RUN apk add --no-cache \
+  php8-pdo_sqlite \
+  php8-sqlite3 \
+  php8-xdebug
+
+# Enable the xdebug extension.
+# `/etc/php` has been symlinked to `/etc/php{version}` on the parent container for ease of use.
+RUN echo zend_extension=xdebug.so >> /etc/php/conf.d/xdebug.ini
+ENV XDEBUG_MODE=coverage


### PR DESCRIPTION
Introduce development docker containers. This will allow for an easier time bootstrapping development environments for projects that use the main docker container.

Development containers include the following extra dependencies;

* `php-pdo_sqlite`
* `php-sqlite3`
* `php-xdebug`

The containers will also automatically enable the `xdebug` extension and configure it for code coverage support.