### PR TITLE
feat: add support for arm images via buildx

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -17,10 +17,10 @@ jobs:
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Build Main Container
-        run: docker build -t defrostedtuna/php-nginx:7.3 . -f php-7.3/Dockerfile
+        run: docker buildx build --no-cache -t defrostedtuna/php-nginx:7.3 . -f php-7.3/Dockerfile
 
       - name: Build Dev Container
-        run: docker build -t defrostedtuna/php-nginx:7.3-dev . -f php-7.3/dev.Dockerfile
+        run: docker buildx build --no-cache -t defrostedtuna/php-nginx:7.3-dev . -f php-7.3/dev.Dockerfile
 
       - name: Push Containers
         run: |
@@ -38,10 +38,10 @@ jobs:
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Build Main Container
-        run: docker build -t defrostedtuna/php-nginx:7.4 . -f php-7.4/Dockerfile
+        run: docker buildx build --no-cache -t defrostedtuna/php-nginx:7.4 . -f php-7.4/Dockerfile
 
       - name: Build Dev Container
-        run: docker build -t defrostedtuna/php-nginx:7.4-dev . -f php-7.4/dev.Dockerfile
+        run: docker buildx build --no-cache -t defrostedtuna/php-nginx:7.4-dev . -f php-7.4/dev.Dockerfile
 
       - name: Push Containers
         run: |
@@ -59,10 +59,10 @@ jobs:
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Build Main Container
-        run: docker build -t defrostedtuna/php-nginx:8.0 . -f php-8.0/Dockerfile
+        run: docker buildx build --no-cache -t defrostedtuna/php-nginx:8.0 . -f php-8.0/Dockerfile
 
       - name: Build Dev Container
-        run: docker build -t defrostedtuna/php-nginx:8.0-dev . -f php-8.0/dev.Dockerfile
+        run: docker buildx build --no-cache -t defrostedtuna/php-nginx:8.0-dev . -f php-8.0/dev.Dockerfile
 
       - name: Push Containers
         run: |

--- a/php-7.3/Dockerfile
+++ b/php-7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM --platform=$BUILDPLATFORM alpine:3.12
 LABEL Maintainer="Rick Bennett <rbennett1106@gmail.com>"
 
 # Essentials

--- a/php-7.3/dev.Dockerfile
+++ b/php-7.3/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM defrostedtuna/php-nginx:7.3
+FROM --platform=$BUILDPLATFORM defrostedtuna/php-nginx:7.3
 
 # Add sqlite and xdebug for development purposes.
 RUN apk add --no-cache \

--- a/php-7.4/Dockerfile
+++ b/php-7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM --platform=$BUILDPLATFORM alpine:3.14
 LABEL Maintainer="Rick Bennett <rbennett1106@gmail.com>"
 
 # Essentials

--- a/php-7.4/dev.Dockerfile
+++ b/php-7.4/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM defrostedtuna/php-nginx:7.4
+FROM --platform=$BUILDPLATFORM defrostedtuna/php-nginx:7.4
 
 # Add sqlite and xdebug for development purposes.
 RUN apk add --no-cache \

--- a/php-8.0/Dockerfile
+++ b/php-8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM --platform=$BUILDPLATFORM alpine:3.14
 LABEL Maintainer="Rick Bennett <rbennett1106@gmail.com>"
 
 # Essentials

--- a/php-8.0/dev.Dockerfile
+++ b/php-8.0/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM defrostedtuna/php-nginx:8.0
+FROM --platform=$BUILDPLATFORM defrostedtuna/php-nginx:8.0
 
 # Add sqlite and xdebug for development purposes.
 RUN apk add --no-cache \


### PR DESCRIPTION
Previously, only `linux/amd64` images we being built for containers. This caused issues with M1 Macs due to the new architecture. This update will build the container for multiple platforms moving forward so that this is no longer an issue.