### PR TITLE
ci: add qemu support

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -16,6 +16,9 @@ jobs:
       - name: Authenticate with Docker Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
+      - name: Add QEMU Support
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
       - name: Build Main Container
         run: docker buildx build --no-cache -t defrostedtuna/php-nginx:7.3 . -f php-7.3/Dockerfile
 
@@ -37,6 +40,9 @@ jobs:
       - name: Authenticate with Docker Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
+      - name: Add QEMU Support
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
       - name: Build Main Container
         run: docker buildx build --no-cache -t defrostedtuna/php-nginx:7.4 . -f php-7.4/Dockerfile
 
@@ -57,6 +63,9 @@ jobs:
 
       - name: Authenticate with Docker Registry
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Add QEMU Support
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
       - name: Build Main Container
         run: docker buildx build --no-cache -t defrostedtuna/php-nginx:8.0 . -f php-8.0/Dockerfile


### PR DESCRIPTION
After adding the multi-arch support to the containers, the multi-arch functionality was not working properly. This update will include QEMU, which is resonsibile for adding the additional dependencies to enable multi-arch support.