### PR TITLE
ci: finalize arm builds

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -9,7 +9,7 @@ jobs:
   build-php-73:
     name: PHP 7.3
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - name: Checkout Code
         uses: actions/checkout@v2
 

--- a/php-7.3/Dockerfile
+++ b/php-7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM alpine:3.12
+FROM alpine:3.12
 LABEL Maintainer="Rick Bennett <rbennett1106@gmail.com>"
 
 # Essentials

--- a/php-7.3/dev.Dockerfile
+++ b/php-7.3/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM defrostedtuna/php-nginx:7.3
+FROM defrostedtuna/php-nginx:7.3
 
 # Add sqlite and xdebug for development purposes.
 RUN apk add --no-cache \

--- a/php-7.4/Dockerfile
+++ b/php-7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM alpine:3.14
+FROM alpine:3.14
 LABEL Maintainer="Rick Bennett <rbennett1106@gmail.com>"
 
 # Essentials

--- a/php-7.4/dev.Dockerfile
+++ b/php-7.4/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM defrostedtuna/php-nginx:7.4
+FROM defrostedtuna/php-nginx:7.4
 
 # Add sqlite and xdebug for development purposes.
 RUN apk add --no-cache \

--- a/php-8.0/Dockerfile
+++ b/php-8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM alpine:3.14
+FROM alpine:3.14
 LABEL Maintainer="Rick Bennett <rbennett1106@gmail.com>"
 
 # Essentials

--- a/php-8.0/dev.Dockerfile
+++ b/php-8.0/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM defrostedtuna/php-nginx:8.0
+FROM defrostedtuna/php-nginx:8.0
 
 # Add sqlite and xdebug for development purposes.
 RUN apk add --no-cache \


### PR DESCRIPTION
Ran into yet another issue with `arm64` builds. Images would build locally without issue, yet would not retain the `arm64` architecture while building via GitHub Actions. Looks like this was due to the platform declaration present in the Dockerfiles themselves. These have been removed and builds are coming through as intended.