### PR TITLE
feat: increase php memory limit on development containers

### DIFF
--- a/php-7.3/dev.Dockerfile
+++ b/php-7.3/dev.Dockerfile
@@ -6,6 +6,9 @@ RUN apk add --no-cache \
   php7-sqlite3 \
   php7-xdebug
 
+# Increase the PHP memory limit for development.
+RUN echo $'\nmemory_limit = 1G' >> /etc/php/php.ini 
+
 # Enable the xdebug extension.
 # `/etc/php` has been symlinked to `/etc/php{version}` on the parent container for ease of use.
 RUN echo zend_extension=xdebug.so >> /etc/php/conf.d/xdebug.ini

--- a/php-7.4/dev.Dockerfile
+++ b/php-7.4/dev.Dockerfile
@@ -6,6 +6,9 @@ RUN apk add --no-cache \
   php7-sqlite3 \
   php7-xdebug
 
+# Increase the PHP memory limit for development.
+RUN echo $'\nmemory_limit = 1G' >> /etc/php/php.ini 
+
 # Enable the xdebug extension.
 # `/etc/php` has been symlinked to `/etc/php{version}` on the parent container for ease of use.
 RUN echo zend_extension=xdebug.so >> /etc/php/conf.d/xdebug.ini

--- a/php-8.0/dev.Dockerfile
+++ b/php-8.0/dev.Dockerfile
@@ -6,6 +6,9 @@ RUN apk add --no-cache \
   php8-sqlite3 \
   php8-xdebug
 
+# Increase the PHP memory limit for development.
+RUN echo $'\nmemory_limit = 1G' >> /etc/php/php.ini 
+
 # Enable the xdebug extension.
 # `/etc/php` has been symlinked to `/etc/php{version}` on the parent container for ease of use.
 RUN echo zend_extension=xdebug.so >> /etc/php/conf.d/xdebug.ini

--- a/php-8.1/dev.Dockerfile
+++ b/php-8.1/dev.Dockerfile
@@ -6,6 +6,9 @@ RUN apk add --no-cache \
   php81-sqlite3 \
   php81-xdebug
 
+# Increase the PHP memory limit for development.
+RUN echo $'\nmemory_limit = 1G' >> /etc/php/php.ini 
+
 # Enable the xdebug extension.
 # `/etc/php` has been symlinked to `/etc/php{version}` on the parent container for ease of use.
 RUN echo zend_extension=xdebug.so >> /etc/php/conf.d/xdebug.ini


### PR DESCRIPTION
Increases the memory limit for PHP development containers from 128MB (default) to 1G. This will resolve issues during development without having to specify this override on each project.